### PR TITLE
Upgrade to Node.js 22 and enhance Docker support

### DIFF
--- a/.github/workflows/rls.deploy.yaml
+++ b/.github/workflows/rls.deploy.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "22.x"
           cache: "npm"
           # Since all node modules is stored in the main directory, we need to
           # use the package-lock.json from the main directory
@@ -80,7 +80,6 @@ jobs:
           image: "medis-rls"
           tags: ${{ steps.extract_branch.outputs.branch}}
           containerfiles: /Dockerfile
-          tls-verify: false
           extra-args: --ulimit nofile=4096:4096
       # Push to specified registry
       - name: Push Static To OpenShift Image repo

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,7 @@
-FROM docker.io/node:22-alpine
+# Uses the official Node.js 22 image as a parent image instead of the slim variant to avoid issues with missing libraries in Alpine.
+# The missing libraries can cause problems when running certain Node.js applications or dependencies that rely on native modules.
+# For example, on arm64 architecture, some native modules may not compile correctly on Alpine due to the absence of required libraries.
+FROM docker.io/node:22
 
 ENV NO_UPDATE_NOTIFIER=true
 WORKDIR /opt/app-root/src/app

--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ Please note that this project is released with a [Contributor Code of Conduct](C
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+## Build
+
+To build the application locally use:
+
+```
+docker build . -t medis-rls:latest
+```
+
+If you are using a machine with an arm64 architecture use:
+
+```
+docker build . -f Dockerfile.local -t medis-rls:latest
+```


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

- Modified the Dockerfile to use the latest version of the official alpine Node.js image with Node.js version 22
- Added a Dockerfile.local file for arm64 machines such as Apple Silicon machines
- Updated README.md in repository root with build instructions
- Modified the GitHub actions workflow to enforce SSL/TLS and to use the same Node.js version as the runtime